### PR TITLE
Feature: Add Swift Concurrency support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "PromiseKit",
-    platforms: [.iOS(.v11)], // The XCFramework bundle (built from the origin PromiseKit) is manually built for specific platforms. Setting this `platforms` value assures that this package is only available to platforms supported by the bundle.
+    platforms: [.iOS(.v11)], // Setting this `platforms` value assures that this package is only available to platforms supported by the XCFramework bundle (built from the origin PromiseKit repo).
     products: [
         .library(
             name: "PromiseKit",

--- a/Package.swift
+++ b/Package.swift
@@ -1,39 +1,31 @@
 // swift-tools-version: 5.6
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "PromiseKit",
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "PromiseKit",
-            targets: ["PromiseKit", "PMKExtensions", "PMKExtensionsObjc"]),
-    ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+            targets: ["PromiseKit", "PMKExtensions", "PMKExtensionsObjc"]
+        ),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .binaryTarget(
             name: "PromiseKit",
             path: "Sources/PromiseKit/PromiseKit.xcframework"
         ),
         .target(
             name: "PMKExtensions",
-            dependencies: ["PromiseKit"],
-            path: "Sources/PMKExtensions"
+            dependencies: ["PromiseKit"]
         ),
         .target(
             name: "PMKExtensionsObjc",
-            dependencies: ["PromiseKit"],
-            path: "Sources/PMKExtensionsObjc"
+            dependencies: ["PromiseKit"]
         ),
         .testTarget(
             name: "PromiseKitTests",
-            dependencies: ["PromiseKit"]),
+            dependencies: ["PromiseKit"]
+        ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "PromiseKit",
+    platforms: [.iOS(.v11)], // The XCFramework bundle (built from the origin PromiseKit) is manually built for specific platforms. Setting this `platforms` value assures that this package is only available to platforms supported by the bundle.
     products: [
         .library(
             name: "PromiseKit",

--- a/Sources/PMKExtensions/AnyPromise+asPromise.swift
+++ b/Sources/PMKExtensions/AnyPromise+asPromise.swift
@@ -1,0 +1,42 @@
+//
+//  AnyPromise+asPromise.swift
+//  PMKExtensions
+//
+//  Created by Bri on 7/30/23.
+//
+
+import PromiseKit
+
+extension AnyPromise {
+    func asPromise<T>() -> Promise<T> {
+        asPromise(type: T.self)
+    }
+
+    func asPromise<T>() -> Promise<T?> {
+        asPromise(type: T.self)
+    }
+
+    func asPromise<T>(type: T.Type) -> Promise<T?> {
+        Promise<T?>.init { resolver in
+            self.done({ value in
+                resolver.fulfill(value as? T)
+            }).catch { error in
+                resolver.reject(error)
+            }
+        }
+    }
+
+    public func asPromise<T>(type: T.Type) -> Promise<T> {
+        Promise<T>.init { resolver in
+            self.done({ value in
+                if let value = value as? T {
+                    return resolver.fulfill(value)
+                }
+
+                throw RSPMKError.failedCastAsPromise(promise: value, to: T.self)
+            }).catch { error in
+                resolver.reject(error)
+            }
+        }
+    }
+}

--- a/Sources/PMKExtensions/Promise+Concurrency.swift
+++ b/Sources/PMKExtensions/Promise+Concurrency.swift
@@ -1,0 +1,49 @@
+//
+//  Promise+Concurrency.swift
+//  PMKExtensions
+//
+//  Created by Bri on 7/30/23.
+//
+
+import PromiseKit
+
+@available(iOS 13.0, *)
+extension Promise {
+    /// Execute this promise using Swift Concurrency. Any caught errors will be thrown.
+    /// - Parameters:
+    ///   - dispatchQueue: The `DispatchQueue` that the `Promise` will be returned or caught on. PromiseKit defaults to returning/catching this `Promise` on the main thread.
+    ///   - flags: The work item flags for the dispatch queue
+    ///   - catchPolicy: Used to skip cancellation errors, or catch all errors (in the `Promise`).
+    /// - Returns: `T`, the specified type.
+    func asTask(
+        on dispatchQueue: DispatchQueue? = nil,
+        flags: DispatchWorkItemFlags? = nil,
+        catchPolicy: CatchPolicy = .allErrorsExceptCancellation
+    ) async throws -> T {
+        try await asTask(returnOn: dispatchQueue, catchOn: dispatchQueue, flags: flags, catchPolicy: catchPolicy)
+    }
+
+    /// Execute this `Promise` using Swift Concurrency. Any caught errors will be thrown.
+    /// - Parameters:
+    ///   - returnQueue: The `DispatchQueue` that the `Promise`'s value will be returned on. PromiseKit defaults to returning/catching this `Promise` on the main thread. ```
+    ///   - catchQueue: The `DispatchQueue` that the `Promise` will be caught on and the error will be handled. PromiseKit defaults to returning/catching this `Promise` on the main thread.
+    ///   - flags: The work item flags for the returning/catching `DispatchQueue`
+    ///   - catchPolicy: Used to skip cancellation errors, or catch all errors (in the `Promise`). (Defaults to `CatchPolicy.allErrorsExceptCancellation`)
+    /// - Returns: `T`, the type specified in this `Promise`.
+    func asTask(
+        returnOn returnQueue: DispatchQueue?,
+        catchOn catchQueue: DispatchQueue?,
+        flags: DispatchWorkItemFlags? = nil,
+        catchPolicy: CatchPolicy = .allErrorsExceptCancellation
+    ) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            firstly { self }
+                .done(on: returnQueue, flags: flags) {
+                    continuation.resume(returning: $0)
+                }
+                .catch(on: catchQueue, flags: flags, policy: catchPolicy) {
+                    continuation.resume(throwing: $0)
+                }
+        }
+    }
+}

--- a/Sources/PMKExtensions/RSPMKError.swift
+++ b/Sources/PMKExtensions/RSPMKError.swift
@@ -1,0 +1,28 @@
+//
+//  RSPMKError.swift
+//  PMKExtensions
+//
+//  Created by Brandon Meyer on 8/7/19.
+//  Copyright © 2019 rewardStyle. All rights reserved.
+//
+
+import PromiseKit
+
+public enum RSPMKError<T>: Error, LocalizedError {
+    case failedCast(to: T.Type)
+    case failedCastAsPromise(promise: AnyPromise.T, to: T.Type)
+
+    public var debugDescription: String {
+        switch self {
+        case .failedCast(let type):
+            return "Failed to cast as \(type)"
+
+        case .failedCastAsPromise(let promise, let to):
+            return "Failed to cast object \(String(describing: promise)) to \(to)"
+        }
+    }
+
+    public var localizedDescription: String {
+        debugDescription
+    }
+}

--- a/Sources/PMKExtensions/TaskPipe.swift
+++ b/Sources/PMKExtensions/TaskPipe.swift
@@ -1,0 +1,115 @@
+//
+//  TaskPipe.swift
+//  Extensions
+//
+//  Created by Bri on 5/12/23.
+//
+
+import Foundation
+import PromiseKit
+
+@available(iOS 13.0, *)
+/// Use `firstly {}` or `.then { _ in }` to create an instance of a `TaskPipe` to inject an `async` task into the beginning or middle of an existing `Promise` chain.
+///
+/// This is useful when you have legacy business logic leveraging promises, but you have a newer service that leverages `async` methods to load a remote resource, or maybe an `actor` that has an isolated scope. This way you can still access these objects and services with `async` interfaces, right inside your current feature's promise chain code.
+public final class TaskPipe<T>: Thenable, CatchMixin {
+    /// The resolved result or nil if pending.
+    /// - Note: `Thenable` conformance
+    public var result: Result<T>?
+
+    /// The internal `async` block that will determine how to resolve the promise chain.
+    var task: () async throws -> T
+
+    /// Create a new `TaskPipe` with an `async` block.
+    /// - Parameter task: The `async` block that will determine how to resolve the promise chain.
+    public init(execute task: @escaping () async throws -> T) {
+        self.task = task
+    }
+
+    /// `pipe` is immediately executed when this `Thenable` is resolved
+    /// - Note: `Thenable` conformance
+    public func pipe(to: @escaping (Result<T>) -> Void) {
+        Task {
+            do {
+                let response = try await task()
+                to(.fulfilled(response))
+            } catch {
+                to(.rejected(error))
+            }
+        }
+    }
+}
+
+/// Judicious use of `firstly` *may* make chains more readable.
+///
+/// Compare:
+/// ```swift
+/// URLSession.shared.dataTask(url: url1).then {
+///     URLSession.shared.dataTask(url: url2)
+/// }.then {
+///     URLSession.shared.dataTask(url: url3)
+/// }
+/// ```
+///
+/// With:
+///
+/// ```swift
+/// firstly {
+///     URLSession.shared.dataTask(url: url1)
+/// }.then {
+///     URLSession.shared.dataTask(url: url2)
+/// }.then {
+///     URLSession.shared.dataTask(url: url3)
+/// }
+/// ```
+///
+/// - Note: the block you pass executes immediately on the current thread/queue.
+/// - Parameter task: The `async` `Task` to be executed. When this `Task` resolves the promise will also resolve with the same value and type.
+/// - Returns: A `TaskPipe` instance, which is `Thenable`.
+@available(iOS 13.0, *)
+public func firstly<T>(execute task: @escaping () async throws -> T) -> TaskPipe<T> {
+    TaskPipe(execute: task)
+}
+
+@available(iOS 13.0, *)
+public extension Thenable {
+    /// The provided closure executes when this promise is fulfilled.
+    ///
+    /// This allows chaining promises. The promise returned by the provided closure is resolved before the promise returned by this closure resolves.
+    ///
+    /// - Parameter on: The queue to which the provided closure dispatches.
+    /// - Parameter body: The closure that executes when this promise is fulfilled. It must return a promise.
+    /// - Returns: A new promise that resolves when the promise returned from the provided closure resolves.
+    ///
+    /// For example:
+    /// ```
+    ///   firstly {
+    ///       URLSession.shared.dataTask(.promise, with: url1)
+    ///   }.then { response in
+    ///       transform(data: response.data)
+    ///   }.done { transformation in
+    ///       //…
+    ///   }
+    /// ```
+    func then<U>(_ body: @escaping (T) async throws -> U) -> Promise<U> {
+        Promise { resolver in
+            pipe { result in
+                switch result {
+                case .fulfilled(let value):
+                    Task {
+                        do {
+                            let result = try await body(value)
+                            resolver.fulfill(result)
+                        } catch {
+                            resolver.reject(error)
+                        }
+                    }
+                case .rejected(let error):
+                    resolver.reject(error)
+                @unknown default:
+                    break
+                }
+            }
+        }
+    }
+}

--- a/Tests/PromiseKitTests/TaskPipeTests.swift
+++ b/Tests/PromiseKitTests/TaskPipeTests.swift
@@ -1,0 +1,129 @@
+//
+//  TaskPipeTests.swift
+//  
+//
+//  Created by Bri on 7/30/23.
+//
+
+import XCTest
+import PromiseKit
+@testable import Extensions
+
+final class TaskPipeTests: XCTestCase {
+
+    let error = NSError(domain: "I am a teapot 🫖", code: 418)
+
+    func failingTask() async throws -> String {
+        throw error
+    }
+
+    func meow() async throws -> String {
+        "Meow"
+    }
+
+    func meow() -> Promise<String> {
+        Promise { resolver in
+            resolver.fulfill("Meow")
+        }
+    }
+
+    func addMeow(to meow: String) async throws -> String {
+        let meow2 = try await self.meow()
+        return [meow, meow2].joined(separator: " ")
+    }
+
+    func addMeow(to meow: String) -> Promise<String> {
+        firstly {
+            self.meow()
+        }
+        .then { meow2 in
+            [meow, meow2].joined(separator: " ")
+        }
+    }
+
+    func testFirstlyThen() {
+        _ = firstly {
+            try await self.meow()
+        }
+        .then { meow in
+            try await self.addMeow(to: meow)
+        }
+        .done { meows in
+            XCTAssertEqual(meows, "meow meow")
+        }
+    }
+
+    func testInterspersedPromisesAndTasks() {
+        _ = firstly {
+            try await self.meow()
+        }
+        .then { meow in
+            self.addMeow(to: meow)
+        }
+        .done { meows in
+            XCTAssertEqual(meows, "meow meow")
+        }
+    }
+
+    func testThrowingFirstly() {
+        _ = firstly {
+            try await self.failingTask()
+        }
+        .catch { error in
+            XCTAssertEqual(error as NSError, self.error)
+        }
+    }
+
+    func testThrowingFirstlyPassthroughThen() {
+        _ = firstly {
+            try await self.failingTask()
+        }
+        .then { meow in
+            self.addMeow(to: meow)
+        }
+        .catch { error in
+            XCTAssertEqual(error as NSError, self.error)
+        }
+    }
+
+    func testThrowingThen() {
+        _ = firstly {
+            self.meow()
+        }
+        .then { meow in
+            try await self.failingTask()
+        }
+        .catch { error in
+            XCTAssertEqual(error as NSError, self.error)
+        }
+    }
+
+    func testWhen() {
+        let firstMeow = meow()
+        let secondMeow = meow()
+        let thirdMeow = meow()
+        let fourthMeow = Promise(
+            TaskPipe {
+                try await self.meow()
+            }
+        )
+        let fifthMeow = Promise(
+            TaskPipe {
+                try await self.meow()
+            }
+        )
+        _ = when(resolved: [firstMeow, secondMeow, thirdMeow, fourthMeow, fifthMeow])
+            .then { results in
+                for result in results {
+                    switch result {
+                    case .fulfilled(let meow):
+                        XCTAssertEqual(meow, "Meow")
+                    case .rejected(let error):
+                        XCTFail("Caught error: " + error.localizedDescription)
+                    @unknown default:
+                        break
+                    }
+                }
+            }
+    }
+}


### PR DESCRIPTION
This PR enables a few inter-ops with PromiseKit and Swift Concurrency.

We have `.asTask()` which allows one to wrap a `Promise<T>` in a `Task`.

We have a new `firstly {}` and a new `.then { _ in }` leveraging `TaskPipe`, which enables wrapping a `Task` in a `Promise<T>`

And we have `.asPromise()` which is a bridge from `AnyPromise` to `Promise<T>`