### PR TITLE
chore: revert Package.swift platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "PromiseKit",
-    platforms: [.iOS(.v13)], // Setting this `platforms` value assures that this package is only available to platforms supported by the XCFramework bundle (built from the origin PromiseKit repo).
+    platforms: [.iOS(.v11)], // Setting this `platforms` value assures that this package is only available to platforms supported by the XCFramework bundle (built from the origin PromiseKit repo).
     products: [
         .library(
             name: "PromiseKit",

--- a/Tests/PromiseKitTests/TaskPipeTests.swift
+++ b/Tests/PromiseKitTests/TaskPipeTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import PromiseKit
 @testable import PMKExtensions
 
+@available(iOS 13.0, *)
 final class TaskPipeTests: XCTestCase {
 
     let error = NSError(domain: "I am a teapot 🫖", code: 418)


### PR DESCRIPTION
The previous MF-1565 change set the platform availability to iOS 13+, which makes sense for the apps, but causes many downstream issues in other packages, so we can simply annotate the tests that failed to compile on Xcode 15 with iOS 13+ availability.